### PR TITLE
ARIAL-36 - update stock daily limit

### DIFF
--- a/.github/workflows/daily_shares_ingestion.yml
+++ b/.github/workflows/daily_shares_ingestion.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          GOOGLE_APPLICATION_CREDENTIALS: gcp-credentials.json # <-- This line is missing
+          GOOGLE_APPLICATION_CREDENTIALS: gcp-credentials.json
           BIGQUERY_DATASET_ID: 'financial_data_landing'
-          PROCESS_LIMIT: '10' # As per the default in your acceptance criteria
+          PROCESS_LIMIT: '150'
         run: python -m data_ingestion.ingest_shares


### PR DESCRIPTION
### Summary

* **What:** Increased the `PROCESS_LIMIT` for the daily shares ingestion script from `10` to `150`.
* **Why:** The previous limit was too low, preventing the ingestion of a sufficient number of stocks each day. This change expands our daily data collection scope.
* **How:** Updated the `PROCESS_LIMIT` environment variable within the `daily_shares_ingestion.yml` GitHub Actions workflow.

---

### Affected Components

*Please check all that apply.*

-   [ ] Python - Data Ingestion Script
-   [ ] dbt - Staging Model
-   [ ] dbt - Marts Model
-   [ ] dbt - Source Definition / Test
-   [ ] dbt - Macro
-   [x] GitHub - CI/CD Workflow
-   [ ] Documentation (e.g., README.md)
-   [ ] Other (please specify):

---

### Key Changes & Rationale

The core change is the modification of the `PROCESS_LIMIT` environment variable in our daily ingestion CI/CD pipeline. The limit was raised from 10 to 150 to ensure we capture a more comprehensive set of stock data daily, moving from a test/initial value to a more production-ready one.

---

### Testing

*Confirm that the following checks have been completed.*

-   [ ] Python & SQL linting passes locally.
-   [ ] `dbt run` executes successfully locally.
-   [ ] `dbt test` passes locally for all relevant models.
-   [ ] Data has been manually validated against the source or expected outcomes.
-   [ ] Downstream dependencies (if any) have been considered.

---

### Documentation

-   [ ] `dbt` model and column descriptions have been updated in `schema.yml` files.
-   [ ] Project-level documentation (e.g., `README.md`) has been updated.
-   [x] Not applicable.
